### PR TITLE
Better handling of URLs catched via sip: URL scheme

### DIFF
--- a/Classes/AccountController.m
+++ b/Classes/AccountController.m
@@ -574,7 +574,16 @@ NSString * const kEmailSIPLabel = @"sip";
 }
 
 - (void)handleCatchedURL {
-    AKSIPURI *uri = [AKSIPURI SIPURIWithString:[self catchedURLString]];
+    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+
+    AKSIPURIFormatter *SIPURIFormatter = [[AKSIPURIFormatter alloc] init];
+    [SIPURIFormatter setFormatsTelephoneNumbers:[defaults boolForKey:kFormatTelephoneNumbers]];
+    [SIPURIFormatter setTelephoneNumberFormatterSplitsLastFourDigits:
+     [defaults boolForKey:kTelephoneNumberFormatterSplitsLastFourDigits]];
+    
+    NSString *catchedURLString = [[self catchedURLString] stringByReplacingOccurrencesOfString:@"sip://" withString:@""];
+    catchedURLString = [[self catchedURLString] stringByReplacingOccurrencesOfString:@"sip:" withString:@""];
+    AKSIPURI *uri = [SIPURIFormatter SIPURIFromString:catchedURLString];
     
     [self setCatchedURLString:nil];
     


### PR DESCRIPTION
While using Telephone I found out that it doesn't correctly handle URLs like "sip:+79261234567", or "sip://+79261234567".

This patch fixes it.