### PR TITLE
Cut properly / improve window title

### DIFF
--- a/Telephone/AccountController.m
+++ b/Telephone/AccountController.m
@@ -333,6 +333,7 @@ NSString * const kEmailSIPLabel = @"sip";
     }
     
     // Set displayed name.
+    [[aCallController window] setTitle:[NSString stringWithFormat:@"↑ %@",[[aCallController window] title]]];
     if ([[destinationURI displayName] length] > 0) {
         [aCallController setDisplayedName:[destinationURI displayName]];
         
@@ -762,7 +763,16 @@ NSString * const kEmailSIPLabel = @"sip";
      [defaults boolForKey:kTelephoneNumberFormatterSplitsLastFourDigits]];
     
     // These variables will be changed during the Address Book search if the record is found.
-    NSString *finalTitle = [[aCall remoteURI] SIPAddress];
+    //NSString *finalTitle = [[aCall remoteURI] SIPAddress];
+
+    NSString *arrow = @"↓ ";
+    if([[[[aCall remoteURI] displayName] substringToIndex:2] isEqualToString:@"↑ "])
+    {
+        arrow = @"↑ ";
+        [[aCall remoteURI] setDisplayName:[[[aCall remoteURI] displayName] substringFromIndex:2]];
+    }
+    NSString *finalTitle = [NSString stringWithFormat:@"%@%@", arrow, [[aCall remoteURI] user]];
+    
     NSString *finalDisplayedName = [SIPURIFormatter stringForObjectValue:[aCall remoteURI]];
     NSString *finalStatus = NSLocalizedString(@"calling",
                                               @"John Smith calling. Somebody is calling us right "


### PR DESCRIPTION
Hello,

This PR solves #119.
It cut window title to phone number only.
In addition, it adds a `↓` for incoming calls, and a `↑` for or outgoing calls.

The `↓` arrow is modified to `↑` if the call is detected to be an outgoing call.
It can be when the Originate function of Asterisk is used (phone rings, you pick up it, then it calls the number you want to reach ; generally used from an address book, a website...).
Asterisk users, for this to work, simply add an outgoing arrow (`↑`) followed by a space in your Originate command, for example :
```
Action: Originate
Channel: SIP/line201
Context: SIP-out
Exten: 001219854783
Priority: 1
Callerid: ↑ Martin BROTHER <001219854783>
```

Thank you very much Alexey :+1: 

Ben