### PR TITLE
Wake from sleep improvements

### DIFF
--- a/Telephone/AccountController.h
+++ b/Telephone/AccountController.h
@@ -50,7 +50,7 @@ extern NSString * const kEmailSIPLabel;
 @property(nonatomic, readonly, strong) id<RingtonePlaybackInteractor> ringtonePlayback;
 
 // A Boolean value indicating whether account is registered.
-@property(nonatomic, assign, getter=isAccountRegistered) BOOL accountRegistered;
+@property(nonatomic, readonly, getter=isAccountRegistered) BOOL accountRegistered;
 
 // An array of call controllers managed by the receiver.
 @property(nonatomic, strong) NSMutableArray *callControllers;
@@ -101,6 +101,7 @@ extern NSString * const kEmailSIPLabel;
 
 // Registers the account adding it to the user agent, if needed. The user agent will be started, if it hasn't been yet.
 - (void)registerAccount;
+- (void)unregisterAccount;
 
 // Removes account from the user agent.
 - (void)removeAccountFromUserAgent;

--- a/Telephone/AccountController.h
+++ b/Telephone/AccountController.h
@@ -99,6 +99,9 @@ extern NSString * const kEmailSIPLabel;
 - (instancetype)initWithSIPAccount:(AKSIPAccount *)account
         ringtonePlayback:(id<RingtonePlaybackInteractor>)ringtonePlayback;
 
+// Registers the account adding it to the user agent, if needed. The user agent will be started, if it hasn't been yet.
+- (void)registerAccount;
+
 // Removes account from the user agent.
 - (void)removeAccountFromUserAgent;
 

--- a/Telephone/AccountController.m
+++ b/Telephone/AccountController.m
@@ -263,6 +263,13 @@ NSString * const kEmailSIPLabel = @"sip";
     [[self window] setFrameAutosaveName:[[self account] SIPAddress]];
 }
 
+- (void)registerAccount {
+    if (![[[NSApp delegate] userAgent] isStarted]) {
+        [self setAttemptingToRegisterAccount:YES];
+    }
+    [self setAccountRegistered:YES];
+}
+
 - (void)removeAccountFromUserAgent {
     NSAssert([self isEnabled], @"Account conroller must be enabled to remove account from the user agent.");
     
@@ -440,9 +447,8 @@ NSString * const kEmailSIPLabel = @"sip";
         
     } else if (selectedItemTag == kSIPAccountAvailable) {
         [self setAccountUnavailable:NO];
-        [self setAttemptingToRegisterAccount:YES];
         [self setShouldPresentRegistrationError:YES];
-        [self setAccountRegistered:YES];
+        [self registerAccount];
     }
 }
 
@@ -1023,8 +1029,7 @@ NSString * const kEmailSIPLabel = @"sip";
 // This is the moment when the application starts doing its main job.
 - (void)networkReachabilityDidBecomeReachable:(NSNotification *)notification {
     if (![self isAccountUnavailable] && ![self isAccountRegistered]) {
-        [self setAttemptingToRegisterAccount:YES];
-        [self setAccountRegistered:YES];
+        [self registerAccount];
     }
 }
 

--- a/Telephone/AccountController.m
+++ b/Telephone/AccountController.m
@@ -68,6 +68,8 @@ NSString * const kEmailSIPLabel = @"sip";
 
 @interface AccountController ()
 
+@property(nonatomic, readonly, getter=isAccountAdded) BOOL accountAdded;
+
 // Timer for account re-registration in case of registration error.
 @property(nonatomic, strong) NSTimer *reRegistrationTimer;
 
@@ -121,8 +123,7 @@ NSString * const kEmailSIPLabel = @"sip";
         [self setReRegistrationTimer:nil];
     }
     
-    if ([[self account] identifier] != kAKSIPUserAgentInvalidIdentifier) {
-        // Account has been added.
+    if ([self isAccountAdded]) {
         [self showConnectingState];
         
         [[self account] setRegistered:flag];
@@ -184,6 +185,10 @@ NSString * const kEmailSIPLabel = @"sip";
             [self setShouldPresentRegistrationError:NO];
         }
     }
+}
+
+- (BOOL)isAccountAdded {
+    return self.account.identifier != kAKSIPUserAgentInvalidIdentifier;
 }
 
 - (void)setAccountDescription:(NSString *)accountDescription {
@@ -268,6 +273,13 @@ NSString * const kEmailSIPLabel = @"sip";
         [self setAttemptingToRegisterAccount:YES];
     }
     [self setAccountRegistered:YES];
+}
+
+- (void)unregisterAccount {
+    if (![self isAccountAdded]) {
+        [self setAttemptingToUnregisterAccount:YES];
+    }
+    [self setAccountRegistered:NO];
 }
 
 - (void)removeAccountFromUserAgent {
@@ -405,7 +417,7 @@ NSString * const kEmailSIPLabel = @"sip";
 }
 
 - (void)makeCallToDestinationRegisteringAccountIfNeeded:(NSString *)destination {
-    if ([[self account] identifier] == kAKSIPUserAgentInvalidIdentifier) {
+    if (![self isAccountAdded]) {
         [self setDestinationToCall:destination];
         [self setAccountRegistered:YES];
     } else {
@@ -437,12 +449,10 @@ NSString * const kEmailSIPLabel = @"sip";
         [self removeAccountFromUserAgent];
         
     } else if (selectedItemTag == kSIPAccountUnavailable) {
-        // Unregister account only if it is registered or it wasn't added to the user agent.
-        if ([self isAccountRegistered] || [[self account] identifier] == kAKSIPUserAgentInvalidIdentifier) {
+        if ([self isAccountRegistered] || ![self isAccountAdded]) {
             [self setAccountUnavailable:YES];
-            [self setAttemptingToUnregisterAccount:YES];
             [self setShouldPresentRegistrationError:YES];
-            [self setAccountRegistered:NO];
+            [self unregisterAccount];
         }
         
     } else if (selectedItemTag == kSIPAccountAvailable) {
@@ -608,9 +618,9 @@ NSString * const kEmailSIPLabel = @"sip";
 // When account registration changes, make appropriate modifications to the UI. A call can also be made from here if
 // the user called from the Address Book or from the application URL handler.
 - (void)SIPAccountRegistrationDidChange:(AKSIPAccount *)account {
-    // Account identifier can be kAKSIPUserAgentInvalidIdentifier if notification on the main thread was delivered after
+    // The account can be not added if notification on the main thread was delivered after
     // user agent had removed the account. Don't bother in that case.
-    if ([[self account] identifier] == kAKSIPUserAgentInvalidIdentifier) {
+    if (![self isAccountAdded]) {
         return;
     }
     

--- a/Telephone/AccountController.m
+++ b/Telephone/AccountController.m
@@ -419,7 +419,7 @@ NSString * const kEmailSIPLabel = @"sip";
 - (void)makeCallToDestinationRegisteringAccountIfNeeded:(NSString *)destination {
     if (![self isAccountAdded]) {
         [self setDestinationToCall:destination];
-        [self setAccountRegistered:YES];
+        [self registerAccount];
     } else {
         [self makeCallToDestination:destination];
     }
@@ -630,10 +630,10 @@ NSString * const kEmailSIPLabel = @"sip";
             [self setReRegistrationTimer:nil];
         }
         
-        // If the account was offline and the user chose Unavailable state, setAccountRegistered:NO will add the account
+        // If the account was offline and the user chose Unavailable state, -unregisterAccount will add the account
         // to the user agent. User agent will register the account. Set the account to Unavailable (unregister it) here.
         if ([self attemptingToUnregisterAccount]) {
-            [self setAccountRegistered:NO];
+            [self unregisterAccount];
             
         } else {
             [self setAccountUnavailable:NO];
@@ -1026,9 +1026,9 @@ NSString * const kEmailSIPLabel = @"sip";
     }
     
     if ([self attemptingToRegisterAccount]) {
-        [self setAccountRegistered:YES];
+        [self registerAccount];
     } else if ([self attemptingToUnregisterAccount]) {
-        [self setAccountRegistered:NO];
+        [self unregisterAccount];
     }
 }
 

--- a/Telephone/AppController.m
+++ b/Telephone/AppController.m
@@ -1532,7 +1532,9 @@ NS_ASSUME_NONNULL_END
 
 - (void)unregisterAllAccounts {
     for (AccountController *controller in [self enabledAccountControllers]) {
-        [controller setAccountRegistered:NO];
+        if ([controller isAccountRegistered]) {
+            [controller unregisterAccount];
+        }
     }
 }
 

--- a/Telephone/AppController.m
+++ b/Telephone/AppController.m
@@ -913,7 +913,8 @@ NS_ASSUME_NONNULL_END
 }
 
 - (void)registerAccountIfManualRegistrationRequired:(AccountController *)controller {
-    if (controller.account.registrar.ak_isIPAddress && [controller.registrarReachability isReachable]) {
+    ServiceAddress *registrar = [[ServiceAddress alloc] initWithString:controller.account.registrar];
+    if (registrar.host.ak_isIPAddress && [controller.registrarReachability isReachable]) {
         [controller registerAccount];
     }
 }

--- a/Telephone/AppController.m
+++ b/Telephone/AppController.m
@@ -898,7 +898,7 @@ NS_ASSUME_NONNULL_END
     }
 }
 
-- (void)registerAllAccountsIfReachable {
+- (void)registerReachableAccounts {
     for (AccountController *controller in [self enabledAccountControllers]) {
         if ([[controller registrarReachability] isReachable]) {
             [controller registerAccount];
@@ -1520,7 +1520,7 @@ NS_ASSUME_NONNULL_END
 
 - (void)workspaceDidWake:(NSNotification *)notification {
     if (self.isUserSessionActive) {
-        [self registerAllAccountsIfReachable];
+        [self registerReachableAccounts];
     }
 }
 

--- a/Telephone/AppController.m
+++ b/Telephone/AppController.m
@@ -890,6 +890,43 @@ NS_ASSUME_NONNULL_END
 }
 
 
+#pragma mark - Account registration
+
+- (void)registerAllAccounts {
+    for (AccountController *controller in [self enabledAccountControllers]) {
+        [controller registerAccount];
+    }
+}
+
+- (void)registerAllAccountsIfReachable {
+    for (AccountController *controller in [self enabledAccountControllers]) {
+        if ([[controller registrarReachability] isReachable]) {
+            [controller registerAccount];
+        }
+    }
+}
+
+- (void)registerAllAccountsWhereManualRegistrationRequired {
+    for (AccountController *accountController in [self enabledAccountControllers]) {
+        [self registerAccountIfManualRegistrationRequired:accountController];
+    }
+}
+
+- (void)registerAccountIfManualRegistrationRequired:(AccountController *)controller {
+    if (controller.account.registrar.ak_isIPAddress && [controller.registrarReachability isReachable]) {
+        [controller registerAccount];
+    }
+}
+
+- (void)unregisterAllAccounts {
+    for (AccountController *controller in [self enabledAccountControllers]) {
+        if ([controller isAccountRegistered]) {
+            [controller unregisterAccount];
+        }
+    }
+}
+
+
 #pragma mark -
 #pragma mark AccountSetupController delegate
 
@@ -1495,40 +1532,6 @@ NS_ASSUME_NONNULL_END
 - (void)workspaceSessionDidBecomeActive:(NSNotification *)notification {
     self.userSessionActive = YES;
     [self registerAllAccounts];
-}
-
-- (void)registerAllAccounts {
-    for (AccountController *controller in [self enabledAccountControllers]) {
-        [controller registerAccount];
-    }
-}
-
-- (void)registerAllAccountsIfReachable {
-    for (AccountController *controller in [self enabledAccountControllers]) {
-        if ([[controller registrarReachability] isReachable]) {
-            [controller registerAccount];
-        }
-    }
-}
-
-- (void)unregisterAllAccounts {
-    for (AccountController *controller in [self enabledAccountControllers]) {
-        if ([controller isAccountRegistered]) {
-            [controller unregisterAccount];
-        }
-    }
-}
-
-- (void)registerAllAccountsWhereManualRegistrationRequired {
-    for (AccountController *accountController in [self enabledAccountControllers]) {
-        [self registerAccountIfManualRegistrationRequired:accountController];
-    }
-}
-
-- (void)registerAccountIfManualRegistrationRequired:(AccountController *)controller {
-    if (controller.account.registrar.ak_isIPAddress && [controller.registrarReachability isReachable]) {
-        [controller registerAccount];
-    }
 }
 
 


### PR DESCRIPTION
* Handle `NSWorkspaceDidWakeNotification`. It wasn’t needed earlier (presumably before 10.9) because the app was receiving reachability callbacks from the OS after computer wakes from sleep.
* Fix an issue where the whole ‘host:port’ string of the registrar was used as a host in `AKNetworkReachability`.

Closes #79, closes #117, closes #144, refs #21.