### PR TITLE
Hotfix 1.1.7

### DIFF
--- a/Telephone/Info.plist
+++ b/Telephone/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.6</string>
+	<string>1.1.7</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>
@@ -40,7 +40,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>117</string>
+	<string>118</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSApplicationCategoryType</key>

--- a/Telephone/SystemAudioDeviceIDs.swift
+++ b/Telephone/SystemAudioDeviceIDs.swift
@@ -57,5 +57,5 @@ private func audioObjectIDsWithBytes(bytes: UnsafeMutablePointer<AudioObjectID>,
 }
 
 private func audioObjectIDCountWithLength(length: UInt32) -> Int {
-    return Int(length) / strideof(AudioObjectID)
+    return objectCount(ofType: AudioObjectID.self, inMemoryLength: Int(length))
 }

--- a/Telephone/SystemAudioDevices.swift
+++ b/Telephone/SystemAudioDevices.swift
@@ -95,7 +95,7 @@ private func audioBufferListAddressWithScope(scope: AudioObjectPropertyScope) ->
 }
 
 private func audioBufferListCountWithLength(length: UInt32) -> Int {
-    return Int(length) / strideof(AudioBufferList)
+    return objectCount(ofType: AudioBufferList.self, inMemoryLength: Int(length))
 }
 
 private func channelCountWithBufferListPointer(bufferListPointer: UnsafeMutableAudioBufferListPointer) -> Int {

--- a/Telephone/SystemAudioObject.swift
+++ b/Telephone/SystemAudioObject.swift
@@ -43,3 +43,7 @@ class SystemAudioObject {
         }
     }
 }
+
+func objectCount<T>(ofType type: T.Type, inMemoryLength length: Int) -> Int {
+    return Int(ceil(Double(length) / Double(strideof(type))))
+}


### PR DESCRIPTION
When using CoreAudio API, the length of the expected data is received separately from receiving the data itself. Furthermore, the expected type is not part of the function signature, but is just specified in the
documentation.

Our code expected that the data length it receives always divides to the size of the expected data type without remainder. But when virtual audio devices are configured in the system (for example, using
the Audio MIDI Setup app) that is not the case.

Closes #221 