### PR TITLE
Composite renaming

### DIFF
--- a/Telephone.xcodeproj/project.pbxproj
+++ b/Telephone.xcodeproj/project.pbxproj
@@ -47,8 +47,8 @@
 		8A57AEA61CBEAF1200A36200 /* AKSIPCallNotifications.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A57AEA51CBEAF1200A36200 /* AKSIPCallNotifications.m */; };
 		8A57AEA71CBEAF1200A36200 /* AKSIPCallNotifications.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A57AEA51CBEAF1200A36200 /* AKSIPCallNotifications.m */; };
 		8A61363B1CC23AA000A087A4 /* SystemAudioDevicesChangeEventTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA277A4D1BD16C9D0030ECE4 /* SystemAudioDevicesChangeEventTarget.swift */; };
-		8A61363C1CC23AB900A087A4 /* SystemAudioDevicesChangeEventTargetComposite.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAC0FFB61BE28CAD00A5C7E5 /* SystemAudioDevicesChangeEventTargetComposite.swift */; };
-		8A61363D1CC23ABC00A087A4 /* SystemAudioDevicesChangeEventTargetCompositeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAC0FFB41BE28C7600A5C7E5 /* SystemAudioDevicesChangeEventTargetCompositeTests.swift */; };
+		8A61363C1CC23AB900A087A4 /* SystemAudioDevicesChangeEventTargets.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAC0FFB61BE28CAD00A5C7E5 /* SystemAudioDevicesChangeEventTargets.swift */; };
+		8A61363D1CC23ABC00A087A4 /* SystemAudioDevicesChangeEventTargetsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAC0FFB41BE28C7600A5C7E5 /* SystemAudioDevicesChangeEventTargetsTests.swift */; };
 		8A61363E1CC23AFF00A087A4 /* SystemAudioDevicesChangeEventTargetSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAC0FFB91BE28D2500A5C7E5 /* SystemAudioDevicesChangeEventTargetSpy.swift */; };
 		8A63ECD41CCFBEC400AEC485 /* DefaultStoreClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A63ECD31CCFBEC400AEC485 /* DefaultStoreClient.swift */; };
 		8A6D96EE1D01DDA900D9C15B /* StoreViewSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A6D96ED1D01DDA900D9C15B /* StoreViewSpy.swift */; };
@@ -733,8 +733,8 @@
 		AABAD7EC0E0C171A00CB5930 /* PreferencesController.m */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 4; lastKnownFileType = sourcecode.c.objc; path = PreferencesController.m; sourceTree = "<group>"; tabWidth = 4; };
 		AABAD7EF0E0C184200CB5930 /* English */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = English; path = English.lproj/Preferences.xib; sourceTree = "<group>"; };
 		AABBB39A1BFA1ABC004A65B5 /* InteractorSpy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InteractorSpy.swift; sourceTree = "<group>"; };
-		AAC0FFB41BE28C7600A5C7E5 /* SystemAudioDevicesChangeEventTargetCompositeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SystemAudioDevicesChangeEventTargetCompositeTests.swift; path = UseCasesTests/SystemAudioDevicesChangeEventTargetCompositeTests.swift; sourceTree = SOURCE_ROOT; };
-		AAC0FFB61BE28CAD00A5C7E5 /* SystemAudioDevicesChangeEventTargetComposite.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SystemAudioDevicesChangeEventTargetComposite.swift; sourceTree = "<group>"; };
+		AAC0FFB41BE28C7600A5C7E5 /* SystemAudioDevicesChangeEventTargetsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SystemAudioDevicesChangeEventTargetsTests.swift; path = UseCasesTests/SystemAudioDevicesChangeEventTargetsTests.swift; sourceTree = SOURCE_ROOT; };
+		AAC0FFB61BE28CAD00A5C7E5 /* SystemAudioDevicesChangeEventTargets.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SystemAudioDevicesChangeEventTargets.swift; sourceTree = "<group>"; };
 		AAC0FFB91BE28D2500A5C7E5 /* SystemAudioDevicesChangeEventTargetSpy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SystemAudioDevicesChangeEventTargetSpy.swift; sourceTree = "<group>"; };
 		AAC0FFBB1BE38ADE00A5C7E5 /* UserAgentNotificationsToEventTargetAdapterTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = UserAgentNotificationsToEventTargetAdapterTests.swift; path = TelephoneTests/UserAgentNotificationsToEventTargetAdapterTests.swift; sourceTree = SOURCE_ROOT; };
 		AAC0FFBD1BE38B3800A5C7E5 /* UserAgentNotificationsToEventTargetAdapter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserAgentNotificationsToEventTargetAdapter.swift; sourceTree = "<group>"; };
@@ -1116,8 +1116,8 @@
 				AA32F7ED1BC43FB100FAC228 /* PreferredSoundIOTests.swift */,
 				AA7F6D4A1C0387160064DA3A /* PresentationSoundIO.swift */,
 				AA277A4D1BD16C9D0030ECE4 /* SystemAudioDevicesChangeEventTarget.swift */,
-				AAC0FFB61BE28CAD00A5C7E5 /* SystemAudioDevicesChangeEventTargetComposite.swift */,
-				AAC0FFB41BE28C7600A5C7E5 /* SystemAudioDevicesChangeEventTargetCompositeTests.swift */,
+				AAC0FFB61BE28CAD00A5C7E5 /* SystemAudioDevicesChangeEventTargets.swift */,
+				AAC0FFB41BE28C7600A5C7E5 /* SystemAudioDevicesChangeEventTargetsTests.swift */,
 				AA32F8081BC69D8300FAC228 /* SystemAudioDeviceRepository.swift */,
 				AA3FAB991BBAB5000064B2C3 /* UserAgentAudioDevice.swift */,
 				AAB32A0E1BEB8AC40016C8E6 /* UserAgentAudioDeviceUpdateInteractor.swift */,
@@ -1978,7 +1978,7 @@
 				8A7E21541CC411F3000D02C3 /* ServiceAddress.swift in Sources */,
 				8ADD31CD1CC165C3008C083C /* DelayingUserAgentSoundIOSelectionInteractor.swift in Sources */,
 				8A7567371CF7242800D91C04 /* PurchaseRestorationInteractor.swift in Sources */,
-				8A61363C1CC23AB900A087A4 /* SystemAudioDevicesChangeEventTargetComposite.swift in Sources */,
+				8A61363C1CC23AB900A087A4 /* SystemAudioDevicesChangeEventTargets.swift in Sources */,
 				AA1019771C48071700869D01 /* RingtoneFactory.swift in Sources */,
 				AA3905321BFFDDDA005A8AA3 /* UserAgentAudioDeviceUpdateInteractor.swift in Sources */,
 				AA3905411BFFDE37005A8AA3 /* UserAgentEventTarget.swift in Sources */,
@@ -2035,7 +2035,7 @@
 				AA7F6D451C0381650064DA3A /* UserDefaultsSoundIOLoadInteractorTests.swift in Sources */,
 				AA39053D1BFFDDED005A8AA3 /* UserAgentSoundIOSelectionInteractorTests.swift in Sources */,
 				8ADD6A711CE0DECC001EDBBA /* StoreClientEventTargetsTests.swift in Sources */,
-				8A61363D1CC23ABC00A087A4 /* SystemAudioDevicesChangeEventTargetCompositeTests.swift in Sources */,
+				8A61363D1CC23ABC00A087A4 /* SystemAudioDevicesChangeEventTargetsTests.swift in Sources */,
 				8A7874F01C5A25D0002494ED /* ConditionalRingtonePlaybackInteractorTests.swift in Sources */,
 				AA1019711C48044900869D01 /* DefaultRingtonePlaybackInteractorTests.swift in Sources */,
 				8A11A0C71CCF9D68007BFC7F /* ProductsFetchInteractorTests.swift in Sources */,

--- a/Telephone.xcodeproj/project.pbxproj
+++ b/Telephone.xcodeproj/project.pbxproj
@@ -199,8 +199,8 @@
 		AA39053C1BFFDDED005A8AA3 /* PreferredSoundIOTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA32F7ED1BC43FB100FAC228 /* PreferredSoundIOTests.swift */; };
 		AA39053D1BFFDDED005A8AA3 /* UserAgentSoundIOSelectionInteractorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAFA2BB01BCD814000066CFC /* UserAgentSoundIOSelectionInteractorTests.swift */; };
 		AA3905411BFFDE37005A8AA3 /* UserAgentEventTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA277A631BD542C80030ECE4 /* UserAgentEventTarget.swift */; };
-		AA3905441BFFDE75005A8AA3 /* UserAgentEventTargetComposite.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA25AB511BE0F7FB00E677A4 /* UserAgentEventTargetComposite.swift */; };
-		AA3905461BFFDE7C005A8AA3 /* UserAgentEventTargetCompositeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA25AB4F1BE0F7B600E677A4 /* UserAgentEventTargetCompositeTests.swift */; };
+		AA3905441BFFDE75005A8AA3 /* UserAgentEventTargets.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA25AB511BE0F7FB00E677A4 /* UserAgentEventTargets.swift */; };
+		AA3905461BFFDE7C005A8AA3 /* UserAgentEventTargetsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA25AB4F1BE0F7B600E677A4 /* UserAgentEventTargetsTests.swift */; };
 		AA3905471BFFDE9A005A8AA3 /* UserDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA32F7FD1BC6908300FAC228 /* UserDefaults.swift */; };
 		AA39054A1BFFE125005A8AA3 /* DomainUserAgentAudioDeviceExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA3905491BFFE125005A8AA3 /* DomainUserAgentAudioDeviceExtension.swift */; };
 		AA3A14FB0F309C7C00C45739 /* AKABAddressBook+Localizing.m in Sources */ = {isa = PBXBuildFile; fileRef = AA3A14FA0F309C7C00C45739 /* AKABAddressBook+Localizing.m */; };
@@ -574,8 +574,8 @@
 		AA19CFF41BED148A00991CAA /* DefaultInteractorFactory.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DefaultInteractorFactory.swift; sourceTree = "<group>"; };
 		AA1A0A9F1828E38900278658 /* Telephone.icns */ = {isa = PBXFileReference; lastKnownFileType = image.icns; path = Telephone.icns; sourceTree = "<group>"; };
 		AA1D80121BA9A857004E0855 /* CallController+Protected.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "CallController+Protected.h"; sourceTree = "<group>"; };
-		AA25AB4F1BE0F7B600E677A4 /* UserAgentEventTargetCompositeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = UserAgentEventTargetCompositeTests.swift; path = UseCasesTests/UserAgentEventTargetCompositeTests.swift; sourceTree = SOURCE_ROOT; };
-		AA25AB511BE0F7FB00E677A4 /* UserAgentEventTargetComposite.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserAgentEventTargetComposite.swift; sourceTree = "<group>"; };
+		AA25AB4F1BE0F7B600E677A4 /* UserAgentEventTargetsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = UserAgentEventTargetsTests.swift; path = UseCasesTests/UserAgentEventTargetsTests.swift; sourceTree = SOURCE_ROOT; };
+		AA25AB511BE0F7FB00E677A4 /* UserAgentEventTargets.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserAgentEventTargets.swift; sourceTree = "<group>"; };
 		AA25AB541BE0F86E00E677A4 /* UserAgentEventTargetSpy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserAgentEventTargetSpy.swift; sourceTree = "<group>"; };
 		AA277A4D1BD16C9D0030ECE4 /* SystemAudioDevicesChangeEventTarget.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SystemAudioDevicesChangeEventTarget.swift; sourceTree = "<group>"; };
 		AA277A521BD174D60030ECE4 /* DelayingUserAgentSoundIOSelectionInteractor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DelayingUserAgentSoundIOSelectionInteractor.swift; sourceTree = "<group>"; };
@@ -1138,8 +1138,8 @@
 			children = (
 				AAFA2BB31BCD815100066CFC /* UserAgent.swift */,
 				AA277A631BD542C80030ECE4 /* UserAgentEventTarget.swift */,
-				AA25AB511BE0F7FB00E677A4 /* UserAgentEventTargetComposite.swift */,
-				AA25AB4F1BE0F7B600E677A4 /* UserAgentEventTargetCompositeTests.swift */,
+				AA25AB511BE0F7FB00E677A4 /* UserAgentEventTargets.swift */,
+				AA25AB4F1BE0F7B600E677A4 /* UserAgentEventTargetsTests.swift */,
 			);
 			name = "User Agent";
 			sourceTree = "<group>";
@@ -1996,7 +1996,7 @@
 				8ADD6A4B1CDCF75D001EDBBA /* StoreInteractorFactory.swift in Sources */,
 				8AC1A4411C67BFA8007778A2 /* SoundEventTarget.swift in Sources */,
 				AA3905471BFFDE9A005A8AA3 /* UserDefaults.swift in Sources */,
-				AA3905441BFFDE75005A8AA3 /* UserAgentEventTargetComposite.swift in Sources */,
+				AA3905441BFFDE75005A8AA3 /* UserAgentEventTargets.swift in Sources */,
 				AA7F6D471C0381C00064DA3A /* UserDefaultsSoundIOLoadInteractor.swift in Sources */,
 				AA31663B1C4FB30800E7ECA5 /* UserDefaultsRingtoneSoundConfigurationLoadInteractor.swift in Sources */,
 				AA3905311BFFDDDA005A8AA3 /* UserAgentSoundIOSelectionInteractor.swift in Sources */,
@@ -2030,7 +2030,7 @@
 			files = (
 				8ADD31CC1CC165B5008C083C /* DelayingUserAgentSoundIOSelectionInteractorTests.swift in Sources */,
 				AA39053C1BFFDDED005A8AA3 /* PreferredSoundIOTests.swift in Sources */,
-				AA3905461BFFDE7C005A8AA3 /* UserAgentEventTargetCompositeTests.swift in Sources */,
+				AA3905461BFFDE7C005A8AA3 /* UserAgentEventTargetsTests.swift in Sources */,
 				8A4D0AFE1C96D6A0005543A2 /* RingtoneOutputUpdateInteractorTests.swift in Sources */,
 				AA7F6D451C0381650064DA3A /* UserDefaultsSoundIOLoadInteractorTests.swift in Sources */,
 				AA39053D1BFFDDED005A8AA3 /* UserAgentSoundIOSelectionInteractorTests.swift in Sources */,

--- a/Telephone/CompositionRoot.swift
+++ b/Telephone/CompositionRoot.swift
@@ -97,7 +97,7 @@ class CompositionRoot: NSObject {
             userAgent: userAgent
         )
         devicesChangeEventSource = SystemAudioDevicesChangeEventSource(
-            target: SystemAudioDevicesChangeEventTargetComposite(
+            target: SystemAudioDevicesChangeEventTargets(
                 targets: [
                     UserAgentAudioDeviceUpdateInteractor(userAgent: userAgent),
                     userAgentSoundIOSelection,

--- a/UseCases/SystemAudioDevicesChangeEventTargets.swift
+++ b/UseCases/SystemAudioDevicesChangeEventTargets.swift
@@ -25,9 +25,7 @@ public class SystemAudioDevicesChangeEventTargets {
 }
 
 extension SystemAudioDevicesChangeEventTargets: SystemAudioDevicesChangeEventTarget {
-   public func systemAudioDevicesDidUpdate() {
-        for target in targets {
-            target.systemAudioDevicesDidUpdate()
-        }
+    public func systemAudioDevicesDidUpdate() {
+        targets.forEach { $0.systemAudioDevicesDidUpdate() }
     }
 }

--- a/UseCases/SystemAudioDevicesChangeEventTargets.swift
+++ b/UseCases/SystemAudioDevicesChangeEventTargets.swift
@@ -1,5 +1,5 @@
 //
-//  SystemAudioDevicesChangeEventTargetCompositeTests.swift
+//  SystemAudioDevicesChangeEventTargets.swift
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
@@ -16,19 +16,18 @@
 //  GNU General Public License for more details.
 //
 
-import UseCases
-import UseCasesTestDoubles
-import XCTest
+public class SystemAudioDevicesChangeEventTargets {
+    private let targets: [SystemAudioDevicesChangeEventTarget]
 
-class SystemAudioDevicesChangeEventTargetCompositeTests: XCTestCase {
-    func testCallsEventTargets() {
-        let target1 = SystemAudioDevicesChangeEventTargetSpy()
-        let target2 = SystemAudioDevicesChangeEventTargetSpy()
-        let sut = SystemAudioDevicesChangeEventTargetComposite(targets: [target1, target2])
+    public init(targets: [SystemAudioDevicesChangeEventTarget]) {
+        self.targets = targets
+    }
+}
 
-        sut.systemAudioDevicesDidUpdate()
-
-        XCTAssertTrue(target1.didCallSystemAudioDevicesDidUpdate)
-        XCTAssertTrue(target2.didCallSystemAudioDevicesDidUpdate)
+extension SystemAudioDevicesChangeEventTargets: SystemAudioDevicesChangeEventTarget {
+   public func systemAudioDevicesDidUpdate() {
+        for target in targets {
+            target.systemAudioDevicesDidUpdate()
+        }
     }
 }

--- a/UseCases/UserAgentEventTargets.swift
+++ b/UseCases/UserAgentEventTargets.swift
@@ -1,5 +1,5 @@
 //
-//  UserAgentEventTargetComposite.swift
+//  UserAgentEventTargets.swift
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
@@ -16,7 +16,7 @@
 //  GNU General Public License for more details.
 //
 
-public class UserAgentEventTargetComposite {
+public class UserAgentEventTargets {
     private let targets: [UserAgentEventTarget]
 
     public init(targets: [UserAgentEventTarget]) {
@@ -24,7 +24,7 @@ public class UserAgentEventTargetComposite {
     }
 }
 
-extension UserAgentEventTargetComposite: UserAgentEventTarget {
+extension UserAgentEventTargets: UserAgentEventTarget {
     public func userAgentDidFinishStarting(userAgent: UserAgent) {
         targets.forEach { $0.userAgentDidFinishStarting(userAgent) }
     }

--- a/UseCasesTests/ProductsFetchInteractorTests.swift
+++ b/UseCasesTests/ProductsFetchInteractorTests.swift
@@ -65,7 +65,7 @@ class ProductsFetchInteractorTests: XCTestCase {
         XCTAssertEqual(output.invokedError, error)
     }
 
-    func testAddsItselfToEventTargetCompositeOnExecution() {
+    func testAddsItselfToEventTargetsOnExecution() {
         let targets = StoreClientEventTargets()
         let sut = ProductsFetchInteractor(
             productIdentifiers: [], client: StoreClientSpy(), targets: targets, output: ProductsFetchInteractorOutputSpy()
@@ -76,7 +76,7 @@ class ProductsFetchInteractorTests: XCTestCase {
         XCTAssertTrue(targets[0] === sut)
     }
 
-    func testRemovesItselfFromEventTargetCompositeOnFetchSuccess() {
+    func testRemovesItselfFromEventTargetsOnFetchSuccess() {
         let targets = StoreClientEventTargets()
         let sut = ProductsFetchInteractor(
             productIdentifiers: [], client: StoreClientSpy(), targets: targets, output: ProductsFetchInteractorOutputSpy()
@@ -88,7 +88,7 @@ class ProductsFetchInteractorTests: XCTestCase {
         XCTAssertEqual(targets.count, 0)
     }
 
-    func testRemovesItselfFromEventTargetCompositeOnFetchFailure() {
+    func testRemovesItselfFromEventTargetsOnFetchFailure() {
         let targets = StoreClientEventTargets()
         let sut = ProductsFetchInteractor(
             productIdentifiers: [], client: StoreClientSpy(), targets: targets, output: ProductsFetchInteractorOutputSpy()

--- a/UseCasesTests/SystemAudioDevicesChangeEventTargetsTests.swift
+++ b/UseCasesTests/SystemAudioDevicesChangeEventTargetsTests.swift
@@ -1,5 +1,5 @@
 //
-//  SystemAudioDevicesChangeEventTargetComposite.swift
+//  SystemAudioDevicesChangeEventTargetsTests.swift
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
@@ -16,18 +16,19 @@
 //  GNU General Public License for more details.
 //
 
-public class SystemAudioDevicesChangeEventTargetComposite {
-    private let targets: [SystemAudioDevicesChangeEventTarget]
+import UseCases
+import UseCasesTestDoubles
+import XCTest
 
-    public init(targets: [SystemAudioDevicesChangeEventTarget]) {
-        self.targets = targets
-    }
-}
+class SystemAudioDevicesChangeEventTargetsTests: XCTestCase {
+    func testCallsEventTargets() {
+        let target1 = SystemAudioDevicesChangeEventTargetSpy()
+        let target2 = SystemAudioDevicesChangeEventTargetSpy()
+        let sut = SystemAudioDevicesChangeEventTargets(targets: [target1, target2])
 
-extension SystemAudioDevicesChangeEventTargetComposite: SystemAudioDevicesChangeEventTarget {
-   public func systemAudioDevicesDidUpdate() {
-        for target in targets {
-            target.systemAudioDevicesDidUpdate()
-        }
+        sut.systemAudioDevicesDidUpdate()
+
+        XCTAssertTrue(target1.didCallSystemAudioDevicesDidUpdate)
+        XCTAssertTrue(target2.didCallSystemAudioDevicesDidUpdate)
     }
 }

--- a/UseCasesTests/UserAgentEventTargetsTests.swift
+++ b/UseCasesTests/UserAgentEventTargetsTests.swift
@@ -1,5 +1,5 @@
 //
-//  UserAgentEventTargetCompositeTests.swift
+//  UserAgentEventTargetsTests.swift
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
@@ -20,8 +20,8 @@ import UseCases
 import UseCasesTestDoubles
 import XCTest
 
-class UserAgentEventTargetCompositeTests: XCTestCase {
-    private var sut: UserAgentEventTargetComposite!
+class UserAgentEventTargetsTests: XCTestCase {
+    private var sut: UserAgentEventTargets!
     private var target1: UserAgentEventTargetSpy!
     private var target2: UserAgentEventTargetSpy!
     private var userAgent: UserAgentSpy!
@@ -30,7 +30,7 @@ class UserAgentEventTargetCompositeTests: XCTestCase {
         super.setUp()
         target1 = UserAgentEventTargetSpy()
         target2 = UserAgentEventTargetSpy()
-        sut = UserAgentEventTargetComposite(targets: [target1, target2])
+        sut = UserAgentEventTargets(targets: [target1, target2])
         userAgent = UserAgentSpy()
     }
 


### PR DESCRIPTION
Change object name suffix from EventTargetComposite to EventTargets.

Closes #228