### PR TITLE
Use hard-coded product names

### DIFF
--- a/Telephone.xcodeproj/project.pbxproj
+++ b/Telephone.xcodeproj/project.pbxproj
@@ -210,6 +210,7 @@
 		8ADE59931D61D6A200B41275 /* SHA256Fingerprint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ADE59921D61D6A200B41275 /* SHA256Fingerprint.swift */; };
 		8ADE59951D61E8F700B41275 /* DeviceGUID.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ADE59941D61E8F700B41275 /* DeviceGUID.swift */; };
 		8AE348581D3FC5E0005F9981 /* NoActivePurchasesReceipt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AE348571D3FC5E0005F9981 /* NoActivePurchasesReceipt.swift */; };
+		8AE396CC1D6B2F3800DCFB9E /* ExpectedProducts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AE396CB1D6B2F3800DCFB9E /* ExpectedProducts.swift */; };
 		8AE7062F1D491C220060FF4F /* ReceiptValidation.xpc in Embed XPC Services */ = {isa = PBXBuildFile; fileRef = 8AE706231D491C220060FF4F /* ReceiptValidation.xpc */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		8AE7063D1D4A4D370060FF4F /* ReceiptXPCGateway.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AE7063C1D4A4D370060FF4F /* ReceiptXPCGateway.swift */; };
 		8D11072B0486CEB800E47090 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 089C165CFE840E0CC02AAC07 /* InfoPlist.strings */; };
@@ -730,6 +731,7 @@
 		8ADE59921D61D6A200B41275 /* SHA256Fingerprint.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SHA256Fingerprint.swift; sourceTree = "<group>"; };
 		8ADE59941D61E8F700B41275 /* DeviceGUID.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeviceGUID.swift; sourceTree = "<group>"; };
 		8AE348571D3FC5E0005F9981 /* NoActivePurchasesReceipt.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NoActivePurchasesReceipt.swift; sourceTree = "<group>"; };
+		8AE396CB1D6B2F3800DCFB9E /* ExpectedProducts.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExpectedProducts.swift; sourceTree = "<group>"; };
 		8AE706231D491C220060FF4F /* ReceiptValidation.xpc */ = {isa = PBXFileReference; explicitFileType = "wrapper.xpc-service"; includeInIndex = 0; path = ReceiptValidation.xpc; sourceTree = BUILT_PRODUCTS_DIR; };
 		8AE7062B1D491C220060FF4F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		8AE706331D4A2E180060FF4F /* ReceiptValidation-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "ReceiptValidation-Bridging-Header.h"; sourceTree = "<group>"; };
@@ -1329,6 +1331,7 @@
 			isa = PBXGroup;
 			children = (
 				8ADD6A4C1CDCF805001EDBBA /* DefaultStoreUseCaseFactory.swift */,
+				8AE396CB1D6B2F3800DCFB9E /* ExpectedProducts.swift */,
 				8A7C4F781CD104E300EC7C1B /* PresentationProduct.swift */,
 				8A7C4F701CCFC69F00EC7C1B /* Product+SKProduct.swift */,
 				8A859A061D2EC66500118A66 /* Products */,
@@ -2457,6 +2460,7 @@
 				AAEE7C310ECD953200A7DEB4 /* AKNSWindow+Resizing.m in Sources */,
 				8AC1A43C1C679DA8007778A2 /* NSSoundToSoundAdapterFactory.swift in Sources */,
 				8A9175AD1CABF61200354E26 /* UserAgentError.swift in Sources */,
+				8AE396CC1D6B2F3800DCFB9E /* ExpectedProducts.swift in Sources */,
 				AACD92D00ED434DD00AF8D17 /* AKActiveCallView.m in Sources */,
 				AA2C03F51BD7D827001D25F9 /* AKSIPUserAgent+UserAgent.swift in Sources */,
 				8A7874F81C5A2F4D002494ED /* AppController+ConditionalRingtonePlaybackUseCaseDelegate.swift in Sources */,

--- a/Telephone/CompositionRoot.swift
+++ b/Telephone/CompositionRoot.swift
@@ -63,10 +63,7 @@ final class CompositionRoot: NSObject {
         let storeViewController = StoreViewController(
             target: NullStoreViewEventTarget(), workspace: NSWorkspace.sharedWorkspace()
         )
-        let products = SKProductsRequestToProductsAdapter(
-            identifiers: ["com.tlphn.Telephone.iap.month", "com.tlphn.Telephone.iap.year"],
-            target: productsEventTargets
-        )
+        let products = SKProductsRequestToProductsAdapter(expected: ExpectedProducts(), target: productsEventTargets)
         let store = SKPaymentQueueToStoreAdapter(queue: SKPaymentQueue.defaultQueue(), products: products)
         let receipt = LoggingReceipt(origin: BundleReceipt(bundle: NSBundle.mainBundle(), gateway: ReceiptXPCGateway()))
         let storeViewEventTarget = DefaultStoreViewEventTarget(

--- a/Telephone/ExpectedProducts.swift
+++ b/Telephone/ExpectedProducts.swift
@@ -1,5 +1,5 @@
 //
-//  Product+SKProduct.swift
+//  ExpectedProducts.swift
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
@@ -16,24 +16,17 @@
 //  GNU General Public License for more details.
 //
 
-import StoreKit
-import UseCases
+struct ExpectedProducts {
+    private let map = [
+        "com.tlphn.Telephone.iap.month": NSLocalizedString("1-month optional patronage", comment: "Product name."),
+        "com.tlphn.Telephone.iap.year": NSLocalizedString("12-months optional patronage", comment: "Product name.")
+    ]
 
-extension Product {
-    init(product: SKProduct, name: String, formatter: NSNumberFormatter) {
-        self.init(
-            identifier: product.productIdentifier!,
-            name: name,
-            price: product.price ?? NSDecimalNumber.zero(),
-            localizedPrice: localized(product.price, formatter: formatter)
-        )
+    var identifiers: Set<String> {
+        return Set(map.keys)
     }
-}
 
-private func localized(price: NSDecimalNumber?, formatter: NSNumberFormatter) -> String {
-    if let number = price, string = formatter.stringFromNumber(number) {
-        return string
-    } else {
-        return "N/A"
+    func name(withIdentifier identifier: String) -> String {
+        return map[identifier] ?? NSLocalizedString("Unknown product", comment: "Unknown product name.")
     }
 }

--- a/Telephone/StoreViewController.xib
+++ b/Telephone/StoreViewController.xib
@@ -116,8 +116,8 @@ The subscriptions renew automatically and can be canceled any time according to 
                                         <rect key="frame" x="1" y="1" width="435" height="40"/>
                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                         <subviews>
-                                            <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="eH9-SG-F1U">
-                                                <rect key="frame" x="6" y="12" width="100" height="17"/>
+                                            <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="eH9-SG-F1U">
+                                                <rect key="frame" x="6" y="12" width="97" height="17"/>
                                                 <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" title="Table View Cell" id="NEN-L8-9I9">
                                                     <font key="font" metaFont="system"/>
                                                     <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -127,7 +127,7 @@ The subscriptions renew automatically and can be canceled any time according to 
                                                     <binding destination="cBD-EV-Yai" name="value" keyPath="objectValue.name" id="HIf-f4-hIT"/>
                                                 </connections>
                                             </textField>
-                                            <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="zF3-9y-xfi">
+                                            <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="zF3-9y-xfi">
                                                 <rect key="frame" x="352" y="3" width="81" height="32"/>
                                                 <buttonCell key="cell" type="push" title="Button" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="wUB-pq-l64">
                                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
@@ -139,6 +139,12 @@ The subscriptions renew automatically and can be canceled any time according to 
                                                 </connections>
                                             </button>
                                         </subviews>
+                                        <constraints>
+                                            <constraint firstItem="eH9-SG-F1U" firstAttribute="centerY" secondItem="cBD-EV-Yai" secondAttribute="centerY" id="ZKC-2B-Kfy"/>
+                                            <constraint firstAttribute="trailing" secondItem="zF3-9y-xfi" secondAttribute="trailing" constant="8" id="tGl-Ah-Zq3"/>
+                                            <constraint firstItem="zF3-9y-xfi" firstAttribute="centerY" secondItem="cBD-EV-Yai" secondAttribute="centerY" id="uQN-q7-P5m"/>
+                                            <constraint firstItem="eH9-SG-F1U" firstAttribute="leading" secondItem="cBD-EV-Yai" secondAttribute="leading" constant="8" id="vcM-Ci-Fx2"/>
+                                        </constraints>
                                         <connections>
                                             <outlet property="textField" destination="eH9-SG-F1U" id="bnL-0z-Wm3"/>
                                         </connections>


### PR DESCRIPTION
All SKProducts belonging to one subscription group share the same name which makes products in the UI indistinguishable.