### PR TITLE
Hotfix 1.2.1

### DIFF
--- a/ReceiptValidation/main.swift
+++ b/ReceiptValidation/main.swift
@@ -30,7 +30,7 @@ let delegate = DefaultNSXPCListenerDelegate(
                         identifiers: Set(["com.tlphn.Telephone.iap.month", "com.tlphn.Telephone.iap.year"])
                     ),
                     attributes: ReceiptAttributes(
-                        identifier: "com.tlphn.Telephone", version: "1.2", guid: DeviceGUID().dataValue
+                        identifier: "com.tlphn.Telephone", version: "1.2.1", guid: DeviceGUID().dataValue
                     )
                 ),
                 certificate: certificate

--- a/Telephone/AccountSetupController.m
+++ b/Telephone/AccountSetupController.m
@@ -34,7 +34,11 @@ NSString * const AKAccountSetupControllerDidAddAccountNotification = @"AKAccount
 }
 
 - (IBAction)closeSheet:(id)sender {
-    [self.window.sheetParent endSheet:self.window];
+    if (self.window.sheetParent) {
+        [self.window.sheetParent endSheet:self.window];
+    } else {
+        [self.window orderOut:sender];
+    }
 }
 
 - (IBAction)addAccount:(id)sender {

--- a/Telephone/Info.plist
+++ b/Telephone/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.2</string>
+	<string>1.2.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>
@@ -40,7 +40,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>119</string>
+	<string>120</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSApplicationCategoryType</key>


### PR DESCRIPTION
The account setup window can be presented:

1. As a normal window when the app launches without any accounts.
2. As a sheet when it is presented in the account settings.

In 1.2 a bug was introduced where `-orderOut:` was never called resulting in the account setup window not going away after the user pressed Done or Cancel buttons.