### PR TITLE
Do not rely on the ‘call is calling’ callback

### DIFF
--- a/Telephone/AKSIPAccount.h
+++ b/Telephone/AKSIPAccount.h
@@ -102,9 +102,6 @@ extern const NSInteger kAKSIPAccountDefaultReregistrationTime;
 // Presence online status text.
 @property(nonatomic, readonly, copy) NSString *onlineStatusText;
 
-// Calls that belong to the receiver.
-@property(nonatomic, readonly, strong) NSMutableArray *calls;
-
 @property(nonatomic) NSThread *thread;
 
 // Creates and returns an AKSIPAccount object initialized with a given full name, SIP address, registrar, realm, and
@@ -126,6 +123,9 @@ extern const NSInteger kAKSIPAccountDefaultReregistrationTime;
 // Makes a call to a given destination URI.
 - (void)makeCallTo:(AKSIPURI *)destination completion:(void (^)(AKSIPCall *))completion;
 
+- (AKSIPCall *)addCallWithIdentifier:(NSInteger)identifier;
 - (AKSIPCall *)callWithIdentifier:(NSInteger)identifier;
+- (void)removeCall:(AKSIPCall *)call;
+- (void)removeAllCalls;
 
 @end

--- a/Telephone/AKSIPAccount.m
+++ b/Telephone/AKSIPAccount.m
@@ -39,6 +39,12 @@ const NSInteger kAKSIPAccountDefaultReregistrationTime = 300;
 
 @end
 
+@interface AKSIPAccount ()
+
+@property(nonatomic, readonly) NSMutableArray *calls;
+
+@end
+
 @implementation AKSIPAccount
 
 - (void)setProxyPort:(NSUInteger)port {
@@ -241,7 +247,7 @@ const NSInteger kAKSIPAccountDefaultReregistrationTime = 300;
 - (void)makeCallTo:(AKSIPURI *)destination completion:(void (^ _Nonnull)(AKSIPCall * _Nullable))completion {
     void (^onCallMakeCompletion)(BOOL, pjsua_call_id) = ^(BOOL success, pjsua_call_id callID) {
         if (success) {
-            completion([self callWithIdentifier:callID]);
+            completion([self addCallWithIdentifier:callID]);
         } else {
             NSLog(@"Error making call to %@ via account %@", destination, self);
             completion(nil);
@@ -261,6 +267,15 @@ const NSInteger kAKSIPAccountDefaultReregistrationTime = 300;
     dispatch_async(dispatch_get_main_queue(), ^{ parameters.completion(success, callID); });
 }
 
+- (AKSIPCall *)addCallWithIdentifier:(NSInteger)identifier; {
+    AKSIPCall *call = [self callWithIdentifier:identifier];
+    if (!call) {
+        call = [[AKSIPCall alloc] initWithSIPAccount:self identifier:identifier];
+        [self.calls addObject:call];
+    }
+    return call;
+}
+
 - (AKSIPCall *)callWithIdentifier:(NSInteger)identifier {
     for (AKSIPCall *call in self.calls) {
         if (call.identifier == identifier) {
@@ -268,6 +283,14 @@ const NSInteger kAKSIPAccountDefaultReregistrationTime = 300;
         }
     }
     return nil;
+}
+
+- (void)removeCall:(AKSIPCall *)call {
+    [self.calls removeObject:call];
+}
+
+- (void)removeAllCalls {
+    [self.calls removeAllObjects];
 }
 
 @end

--- a/Telephone/AKSIPUserAgent.m
+++ b/Telephone/AKSIPUserAgent.m
@@ -553,7 +553,7 @@ static const BOOL kAKSIPUserAgentDefaultUsesG711Only = NO;
     
     [anAccount.delegate SIPAccountWillRemove:anAccount];
     
-    [[anAccount calls] removeAllObjects];
+    [anAccount removeAllCalls];
     
     pj_status_t status = pjsua_acc_del((pjsua_acc_id)[anAccount identifier]);
     if (status != PJ_SUCCESS) {

--- a/Telephone/CallController.m
+++ b/Telephone/CallController.m
@@ -376,6 +376,7 @@ static const NSTimeInterval kRedialButtonReenableTime = 1.0;
 }
 
 - (void)showEndedCallView {
+    self.window.styleMask |= NSWindowStyleMaskClosable;
     [self showViewController:self.endedCallViewController];
 }
 

--- a/Telephone/PJSUAOnCallReplaced.m
+++ b/Telephone/PJSUAOnCallReplaced.m
@@ -40,7 +40,6 @@ void PJSUAOnCallReplaced(pjsua_call_id oldCallID, pjsua_call_id newCallID) {
         PJ_LOG(3, (THIS_FILE, "Creating AKSIPCall for call %d from replaced callback", newCallID));
         AKSIPUserAgent *userAgent = [AKSIPUserAgent sharedUserAgent];
         AKSIPAccount *account = [userAgent accountWithIdentifier:accountIdentifier];
-        AKSIPCall *call = [[AKSIPCall alloc] initWithSIPAccount:account identifier:newCallID];
-        [account.calls addObject:call];
+        [account addCallWithIdentifier:newCallID];
     });
 }

--- a/Telephone/PJSUAOnCallState.m
+++ b/Telephone/PJSUAOnCallState.m
@@ -92,8 +92,7 @@ void PJSUAOnCallState(pjsua_call_id callID, pjsip_event *event) {
             if (state == kAKSIPCallCallingState) {
                 AKSIPAccount *account = [userAgent accountWithIdentifier:accountIdentifier];
                 if (account != nil) {
-                    call = [[AKSIPCall alloc] initWithSIPAccount:account identifier:callID];
-                    [account.calls addObject:call];
+                    call = [account addCallWithIdentifier:callID];
                 } else {
                     PJ_LOG(3, (THIS_FILE,
                                "Did not create AKSIPCall for call %d during call state change. Could not find account",
@@ -116,7 +115,7 @@ void PJSUAOnCallState(pjsua_call_id callID, pjsip_event *event) {
 
         if (state == kAKSIPCallDisconnectedState) {
             [userAgent stopRingbackForCall:call];
-            [call.account.calls removeObject:call];
+            [call.account removeCall:call];
             [nc postNotificationName:AKSIPCallDidDisconnectNotification object:call];
 
         } else if (state == kAKSIPCallEarlyState) {

--- a/Telephone/PJSUAOnIncomingCall.m
+++ b/Telephone/PJSUAOnIncomingCall.m
@@ -28,15 +28,8 @@ void PJSUAOnIncomingCall(pjsua_acc_id accountID, pjsua_call_id callID, pjsip_rx_
     PJ_LOG(3, (THIS_FILE, "Incoming call for account %d", accountID));
     dispatch_async(dispatch_get_main_queue(), ^{
         AKSIPAccount *account = [[AKSIPUserAgent sharedUserAgent] accountWithIdentifier:accountID];
-
-        // AKSIPCall object is created here when the call is incoming.
-        AKSIPCall *call = [[AKSIPCall alloc] initWithSIPAccount:account identifier:callID];
-
-        [[account calls] addObject:call];
-
+        AKSIPCall *call = [account addCallWithIdentifier:callID];
         [account.delegate SIPAccount:account didReceiveCall:call];
-
-        [[NSNotificationCenter defaultCenter] postNotificationName:AKSIPCallIncomingNotification
-                                                            object:call];
+        [[NSNotificationCenter defaultCenter] postNotificationName:AKSIPCallIncomingNotification object:call];
     });
 }


### PR DESCRIPTION
When ICE is enabled, the ‘call is calling’ callback fires after the function pjsua_call_make_call() returns.

Closes #299