### PR TITLE
Answer calls from notifications

### DIFF
--- a/Telephone/AccountController.m
+++ b/Telephone/AccountController.m
@@ -981,6 +981,9 @@ NSString * const kGerman = @"de";
     NSUserNotification *userNotification = [[NSUserNotification alloc] init];
     userNotification.title = notificationTitle;
     userNotification.informativeText = notificationDescription;
+    userNotification.actionButtonTitle = NSLocalizedString(@"Answer", @"Call answer button.");
+    NSString *decline = NSLocalizedString(@"Decline", @"Call decline button.");
+    userNotification.additionalActions = @[[NSUserNotificationAction actionWithIdentifier:@"decline" title:decline]];
     userNotification.userInfo = @{kUserNotificationCallControllerIdentifierKey: aCallController.identifier};
     [[NSUserNotificationCenter defaultUserNotificationCenter] deliverNotification:userNotification];
 

--- a/Telephone/AppController.m
+++ b/Telephone/AppController.m
@@ -1468,19 +1468,23 @@ NS_ASSUME_NONNULL_END
 
 #pragma mark - NSUserNotificationCenterDelegate
 
-- (void)userNotificationCenter:(NSUserNotificationCenter *)center
-       didActivateNotification:(NSUserNotification *)notification {
-    
+- (void)userNotificationCenter:(NSUserNotificationCenter *)center didActivateNotification:(NSUserNotification *)notification {
     NSString *identifier = notification.userInfo[kUserNotificationCallControllerIdentifierKey];
-    [self showWindowOfCallControllerWithIdentifier:identifier];
-}
-
-- (void)showWindowOfCallControllerWithIdentifier:(NSString *)identifier {
-    CallController *callController = [self callControllerByIdentifier:identifier];
-    if (![NSApp isActive]) {
-        [NSApp activateIgnoringOtherApps:YES];
+    CallController *controller = [self callControllerByIdentifier:identifier];
+    switch (notification.activationType) {
+        case NSUserNotificationActivationTypeContentsClicked:
+            [controller showWindow:self];
+            [center removeDeliveredNotification:notification];
+            break;
+        case NSUserNotificationActivationTypeActionButtonClicked:
+            [controller acceptCall];
+            break;
+        case NSUserNotificationActivationTypeAdditionalActionClicked:
+            [controller hangUpCall];
+            break;
+        default:
+            break;
     }
-    [callController showWindow:nil];
 }
 
 

--- a/Telephone/Info.plist
+++ b/Telephone/Info.plist
@@ -73,5 +73,7 @@
 			</array>
 		</dict>
 	</array>
+	<key>NSUserNotificationAlertStyle</key>
+	<string>alert</string>
 </dict>
 </plist>

--- a/Telephone/de.lproj/Localizable.strings
+++ b/Telephone/de.lproj/Localizable.strings
@@ -7,6 +7,9 @@
 /* Telephone quit confirmation informative text. */
 "All active calls will be disconnected." = "Alle aktiven Gespräche werden beendet.";
 
+/* Call answer button. */
+"Answer" = "Annehmen";
+
 /* Telephone quit confirmation. */
 "Are you sure you want to quit Telephone?" = "Wollen Sie Telefon wirklich beenden?";
 
@@ -65,7 +68,8 @@
 /* SIP user agent start error. */
 "Could not start SIP user agent." = "Konnte SIP user agent nicht starten.";
 
-/* Decline. Call menu item. */
+/* Call decline button.
+ Decline. Call menu item. */
 "Decline" = "Ablehnen";
 
 /* Delete button. */

--- a/Telephone/en.lproj/Localizable.strings
+++ b/Telephone/en.lproj/Localizable.strings
@@ -7,6 +7,9 @@
 /* Telephone quit confirmation informative text. */
 "All active calls will be disconnected." = "All active calls will be disconnected.";
 
+/* Call answer button. */
+"Answer" = "Answer";
+
 /* Telephone quit confirmation. */
 "Are you sure you want to quit Telephone?" = "Are you sure you want to quit Telephone?";
 
@@ -65,7 +68,8 @@
 /* SIP user agent start error. */
 "Could not start SIP user agent." = "Could not start SIP user agent.";
 
-/* Decline. Call menu item. */
+/* Call decline button.
+   Decline. Call menu item. */
 "Decline" = "Decline";
 
 /* Delete button. */

--- a/Telephone/ru.lproj/Localizable.strings
+++ b/Telephone/ru.lproj/Localizable.strings
@@ -7,6 +7,9 @@
 /* Telephone quit confirmation informative text. */
 "All active calls will be disconnected." = "Будут прекращены все незавершенные звонки.";
 
+/* Call answer button. */
+"Answer" = "Ответить";
+
 /* Telephone quit confirmation. */
 "Are you sure you want to quit Telephone?" = "Вы действительно хотите выйти из Телефона?";
 
@@ -65,7 +68,8 @@
 /* SIP user agent start error. */
 "Could not start SIP user agent." = "Не удалось запустить SIP-подсистему.";
 
-/* Decline. Call menu item. */
+/* Call decline button.
+ Decline. Call menu item. */
 "Decline" = "Отклонить";
 
 /* Delete button. */


### PR DESCRIPTION
The system notifications now have two buttons: Close and Answer. The action of the Close button can’t be changed, the button dismisses the notification without making the app active. The Answer button answers the call. There is also an additional Decline action. The button for it is displayed when you hold the Answer button. This is a system behavior for the additional actions that, unfortunately, can’t be changed.

Closes #170 